### PR TITLE
Adding edit product description functionality

### DIFF
--- a/app/models/product.py
+++ b/app/models/product.py
@@ -103,3 +103,12 @@ WHERE uid=:uid AND pid=:pid AND sid=:sid
     RETURNING pid
     ''',            uid=uid, pid=pid, sid=sid,quantity=quantity)
             return rows[0] if rows is not None else None
+            
+    def update_product_description(pid, sid, description):
+        rows = app.db.execute(f"""
+UPDATE Inventory
+SET description = '{description}'
+WHERE pid={pid} AND sid={sid}
+RETURNING pid
+""")
+        return None

--- a/app/products.py
+++ b/app/products.py
@@ -1,6 +1,6 @@
 from flask import render_template, redirect, url_for, flash
 from flask_wtf import FlaskForm
-from wtforms import IntegerField, SubmitField
+from wtforms import IntegerField, SubmitField, StringField
 from .models.product import Product
 from .models.cart import Cart
 from .models.purchase import OrderDetail
@@ -10,6 +10,9 @@ from flask_login import current_user
 from flask import Blueprint
 bp = Blueprint('products', __name__)
 
+class EditProductDetailsForm(FlaskForm):
+    description = StringField('Description')
+    submit = SubmitField('Edit Details')
 
 class AddToCartForm(FlaskForm):
     quantity = IntegerField('Quantity',
@@ -22,6 +25,16 @@ def details(pid):
     seller_info = Product.getSellerInfo(pid)
     return render_template('productdetails.html', avail_products = [product],seller_info = seller_info)
 
+@bp.route('/editproductdetails/<int:pid>/<int:sid>', methods=['GET', 'POST'])
+def editproductdetails(pid, sid):# get all available products for sale:
+    updateform = EditProductDetailsForm()
+    if updateform.validate_on_submit():
+        Product.update_product_description(pid, sid, updateform.description.data)
+        # TODO: I think I need to change the below to call render productdetails page
+        product = Product.get(pid)
+        seller_info = Product.getSellerInfo(pid)
+        return render_template('productdetails.html', avail_products = [product],seller_info = seller_info)
+    return render_template('edit_productdetails.html', pid=pid, sid=sid, updateform=updateform)
 
 @bp.route('/cart', methods=['GET', 'POST'])
 def cart():

--- a/app/templates/edit_productdetails.html
+++ b/app/templates/edit_productdetails.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+<br><br>
+
+  <form action="" method="post" novalidate>
+      {{ updateform.hidden_tag() }}
+      <p>
+        {{ updateform.description.label }}<br/>
+        {{ updateform.description(size=32) }}<br/>
+        {% for error in updateform.description.errors %}
+        <span style="color: red;">[{{ error }}]</span>
+        {% endfor %}
+      </p>
+      <p>
+        {% with messages = get_flashed_messages() %}
+        {% if messages %}
+        <ul>
+          {% for message in messages %}
+          <li>{{ message }}</li>
+          {% endfor %}
+        </ul>
+        {% endif %}
+        {% endwith %}
+      </p>
+      {{ updateform.submit(class_="btn btn-black") }}
+  </form>
+
+{% endblock %}

--- a/app/templates/productdetails.html
+++ b/app/templates/productdetails.html
@@ -40,7 +40,12 @@
   <tbody>
     {% for seller in seller_info %}
     <tr>
-        <td><a href= "{{url_for('users.publicProfile', variable=seller[0]) }}">{{seller[1]}} {{seller[2]}} </a> </td>
+      <td><a href= "{{url_for('users.publicProfile', variable=seller[0]) }}">{{seller[1]}} {{seller[2]}} </a>
+        {% if current_user.is_authenticated and current_user.id==seller[0] %}
+          <br>
+          <a href="{{url_for('products.editproductdetails', sid=seller[0], pid=avail_products[0].id) }}" class="btn btn-primary btn-lg" role="button">Edit Product Details</a> 
+        {% endif %}          
+      </td>
         <td> {{seller[3]}} </td>
         <td> {{seller[4]}} </td>
         <td> {{seller[5]}} </td>


### PR DESCRIPTION
Adding new page for authenticated users to edit the product details for products they are selling.

New "edit product details" button will show up under authenticated users' names on the product details page if they are selling a product:
<img width="800" alt="image" src="https://user-images.githubusercontent.com/8772103/161855910-9c8b3662-ba94-4f09-a1d5-76c8d830f17c.png">

If you click on it, it will prompt you with a form to update the description. Click "Edit Details" will update the description and bring you back to the productdetails page.
<img width="800" alt="image" src="https://user-images.githubusercontent.com/8772103/161856042-f276c2b5-70b2-4fdc-992f-1b60c28889b8.png">

